### PR TITLE
Weryfikacja ról w Spring Security

### DIFF
--- a/backend/src/main/java/com/kateringapp/backend/configurations/KeycloakJwtRolesConverter.java
+++ b/backend/src/main/java/com/kateringapp/backend/configurations/KeycloakJwtRolesConverter.java
@@ -1,0 +1,37 @@
+package com.kateringapp.backend.configurations;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class KeycloakJwtRolesConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+
+  public static final String PREFIX_REALM_ROLE = "ROLE_";
+  private static final String CLAIM_REALM_ACCESS = "realm_access";
+  private static final String CLAIM_ROLES = "roles";
+
+  @Override
+  public List<GrantedAuthority> convert(Jwt jwt) {
+    List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+    Map<String, Collection<String>> realmAccess = jwt.getClaim(CLAIM_REALM_ACCESS);
+
+    if (realmAccess != null && !realmAccess.isEmpty()) {
+      Collection<String> roles = realmAccess.get(CLAIM_ROLES);
+      if (roles != null && !roles.isEmpty()) {
+        Collection<GrantedAuthority> realmRoles = roles.stream()
+            .map(role -> new SimpleGrantedAuthority(PREFIX_REALM_ROLE + role))
+            .collect(Collectors.toList());
+        grantedAuthorities.addAll(realmRoles);
+      }
+    }
+
+    return grantedAuthorities;
+  }
+}
+

--- a/backend/src/main/java/com/kateringapp/backend/configurations/WebSecurityConfig.java
+++ b/backend/src/main/java/com/kateringapp/backend/configurations/WebSecurityConfig.java
@@ -1,38 +1,53 @@
 package com.kateringapp.backend.configurations;
 
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(securedEnabled = true)
 public class WebSecurityConfig {
 
     private final CorsConfigurationSource corsConfigurationSource;
+
+    Converter<Jwt, Collection<GrantedAuthority>> authoritiesConverter = new KeycloakJwtRolesConverter();
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity.authorizeHttpRequests((authorize) ->
             authorize
                     .requestMatchers(HttpMethod.GET, "/helloWorld").permitAll()
-                    .requestMatchers(HttpMethod.GET, "/secured").authenticated()
+                    .requestMatchers(HttpMethod.GET, "/secured/**").authenticated()
                     .requestMatchers("/swagger-ui/**").permitAll()
                     .requestMatchers("/v3/api-docs/**").permitAll()
                     .anyRequest().authenticated()
             ).oauth2ResourceServer(
-                    oauth2 -> oauth2.jwt(Customizer.withDefaults())
+                    oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
             ).cors(
                     corsSpec -> corsSpec.configurationSource(corsConfigurationSource)
             ).csrf(
                     AbstractHttpConfigurer::disable
             ).build();
+    }
+
+    private Converter<Jwt, AbstractAuthenticationToken> jwtAuthenticationConverter() {
+        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(authoritiesConverter);
+        return jwtAuthenticationConverter;
     }
 }

--- a/backend/src/main/java/com/kateringapp/backend/controllers/HelloWorldController.java
+++ b/backend/src/main/java/com/kateringapp/backend/controllers/HelloWorldController.java
@@ -1,6 +1,12 @@
 package com.kateringapp.backend.controllers;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,4 +25,26 @@ public class HelloWorldController {
     public String secured() {
         return "This is a secured endpoint. You are authenticated.";
     }
+
+    @GetMapping("/secured/roles")
+    public String getUserRoles() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        String roles = authorities.stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(", "));
+
+        return "User roles: " + roles;
+    }
+
+    @Secured("ROLE_client")
+    @GetMapping("/secured/client")
+    @ResponseStatus(HttpStatus.OK)
+    public String securedClient(){ return "This is a secured endpoint only for client"; }
+
+
+    @Secured("ROLE_catering-firm")
+    @GetMapping("/secured/catering-firm")
+    @ResponseStatus(HttpStatus.OK)
+    public String securedCateringFirm(){ return "This is a secured endpoint only for catering-firm"; }
 }

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -4,8 +4,8 @@ spring:
     oauth2:
       resource-server:
         jwt:
-          issuer-uri: http://localhost:8081/realms/KateringApp
-          jwk-set-uri: http://localhost:8081/realms/KateringApp/protocol/openid-connect/certs
+          issuer-uri: http://localhost:8081/realms/kateringapp
+          jwk-set-uri: http://localhost:8081/realms/kateringapp/protocol/openid-connect/certs
 
   h2:
     console.enabled: true # http://localhost:8080/h2-console
@@ -22,3 +22,10 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: true
+
+logging:
+  level:
+    org.springframework.security: DEBUG
+    org.springframework.security.oauth2: DEBUG
+    org.springframework.security.oauth2.server.resource: DEBUG
+    org.springframework.security.oauth2.jwt: DEBUG

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -4,8 +4,8 @@ spring:
     oauth2:
       resource-server:
         jwt:
-          issuer-uri: http://localhost:8081/realms/KateringApp
-          jwk-set-uri: http://keycloak:8081/realms/KateringApp/protocol/openid-connect/certs
+          issuer-uri: http://localhost:8081/realms/kateringapp
+          jwk-set-uri: http://keycloak:8081/realms/kateringapp/protocol/openid-connect/certs
 
   datasource:
     url: ${DB_URL}


### PR DESCRIPTION
Dodałem weryfikację ról w Spring Security. Teraz jeśli w żądaniu do API będzie zawarty token jwt to zostanie poprawnie odczytana rola użytkownika ("client" albo "catering-firm") i można oznaczać które endpointy mają być dostępne dla jakich ról.

Utworzyłem 2 testowe endpointy - jeden tylko dla client, a drugi tylko dla catering-firm.
Można sobie przetestować np. z użyciem Postmana. Access_token, który keycloak wydaje po poprawnym logowaniu kopiujemy do headera Authorization i wysyłamy request pod wybrany url.