### PR TITLE
fixed problem with deleting meals

### DIFF
--- a/backend/src/main/java/com/kateringapp/backend/entities/order/Order.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/order/Order.java
@@ -1,16 +1,7 @@
 package com.kateringapp.backend.entities.order;
 
 import com.kateringapp.backend.entities.Meal;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinColumns;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/com/kateringapp/backend/repositories/IOrderRepository.java
+++ b/backend/src/main/java/com/kateringapp/backend/repositories/IOrderRepository.java
@@ -1,11 +1,16 @@
 package com.kateringapp.backend.repositories;
 
+import com.kateringapp.backend.entities.Meal;
 import com.kateringapp.backend.entities.order.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface IOrderRepository extends JpaRepository<Order, Long>,
         JpaSpecificationExecutor<Order> {
+
+    List<Order> findOrdersByMealsContaining(Meal meal);
 }

--- a/backend/src/main/java/com/kateringapp/backend/services/MealsService.java
+++ b/backend/src/main/java/com/kateringapp/backend/services/MealsService.java
@@ -4,7 +4,6 @@ import com.kateringapp.backend.dtos.MealCreateDTO;
 import com.kateringapp.backend.dtos.MealCriteria;
 import com.kateringapp.backend.dtos.MealGetDTO;
 import com.kateringapp.backend.entities.*;
-import com.kateringapp.backend.entities.order.Order;
 import com.kateringapp.backend.exceptions.BadRequestException;
 import com.kateringapp.backend.exceptions.meal.MealNotFoundException;
 import com.kateringapp.backend.mappers.MealMapper;
@@ -18,7 +17,6 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -69,13 +67,12 @@ public class MealsService implements IMeals{
     }
 
     @Override
-    @Transactional
     public void deleteMeal(Long id) {
         Meal meal = mealRepository.findById(id).orElseThrow(() -> new MealNotFoundException(id));
 
-        List<Order> orders = orderRepository.findOrdersByMealsContaining(meal);
-
-        orderRepository.deleteAll(orders);
+        if(!orderRepository.findOrdersByMealsContaining(meal).isEmpty()){
+            throw new BadRequestException("This meal can't be deleted. There are remaining orders containing this meal.");
+        }
 
         mealRepository.delete(meal);
     }

--- a/backend/src/test/java/com/kateringapp/backend/MealsUnitTest.java
+++ b/backend/src/test/java/com/kateringapp/backend/MealsUnitTest.java
@@ -4,6 +4,7 @@ import com.kateringapp.backend.dtos.MealCreateDTO;
 import com.kateringapp.backend.dtos.MealGetDTO;
 import com.kateringapp.backend.entities.Meal;
 import com.kateringapp.backend.entities.CateringFirmData;
+import com.kateringapp.backend.repositories.IOrderRepository;
 import com.kateringapp.backend.repositories.MealRepository;
 import com.kateringapp.backend.repositories.CateringFirmDataRepository;
 import com.kateringapp.backend.mappers.MealMapper;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Optional;
 
 import static org.mockito.Mockito.*;
@@ -23,6 +25,9 @@ class MealsUnitTest {
 
     @Mock
     private MealRepository mealRepository;
+
+    @Mock
+    private IOrderRepository orderRepository;
 
     @Mock
     private CateringFirmDataRepository cateringFirmDataRepository;
@@ -130,6 +135,7 @@ class MealsUnitTest {
     @Test
     void deleteMeal() {
         when(mealRepository.findById(1L)).thenReturn(Optional.of(meal));
+        when(orderRepository.findOrdersByMealsContaining(meal)).thenReturn(null);
 
         mealsService.deleteMeal(1L);
 

--- a/backend/src/test/java/com/kateringapp/backend/MealsUnitTest.java
+++ b/backend/src/test/java/com/kateringapp/backend/MealsUnitTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.mockito.Mockito.*;
@@ -135,7 +135,7 @@ class MealsUnitTest {
     @Test
     void deleteMeal() {
         when(mealRepository.findById(1L)).thenReturn(Optional.of(meal));
-        when(orderRepository.findOrdersByMealsContaining(meal)).thenReturn(null);
+        when(orderRepository.findOrdersByMealsContaining(meal)).thenReturn(Collections.emptyList());
 
         mealsService.deleteMeal(1L);
 


### PR DESCRIPTION
Był problem z usuwaniem posiłku jeśli było złożone zamówienie na ten posiłek co jest logiczne. Żeby się nie wysypywało, teraz jeśli usuwa się posiłek usuwa się wszystkie zamówienia powiązane z tym posiłkiem. Jeśli chcemy robić inaczej, np blokować usuwanie posiłków znajdujących się w zamówieniach to dajcie znać. 