### PR TITLE
fix orders

### DIFF
--- a/backend/src/main/java/com/kateringapp/backend/controllers/OrderController.java
+++ b/backend/src/main/java/com/kateringapp/backend/controllers/OrderController.java
@@ -6,6 +6,9 @@ import com.kateringapp.backend.dtos.criteria.OrderCriteria;
 import com.kateringapp.backend.services.interfaces.IOrderService;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,9 +28,10 @@ public class OrderController implements IOrders {
     private final IOrderService orderService;
 
     @Override
+    @Secured("ROLE_client")
     @PostMapping
-    public OrderDTO createOrder(@RequestBody OrderDTO orderDTO) {
-        return orderService.createOrder(orderDTO);
+    public OrderDTO createOrder(@RequestBody OrderDTO orderDTO, @AuthenticationPrincipal Jwt token) {
+        return orderService.createOrder(orderDTO, token);
     }
 
     @Override
@@ -44,8 +48,9 @@ public class OrderController implements IOrders {
 
     @Override
     @GetMapping
-    public List<OrderDTO> getOrders(@ParameterObject OrderCriteria orderCriteria) {
-        return orderService.getOrders(orderCriteria);
+    public List<OrderDTO> getOrders(
+            @ParameterObject OrderCriteria orderCriteria, @AuthenticationPrincipal Jwt token) {
+        return orderService.getOrders(orderCriteria, token);
     }
 
     @Override

--- a/backend/src/main/java/com/kateringapp/backend/controllers/interfaces/IOrders.java
+++ b/backend/src/main/java/com/kateringapp/backend/controllers/interfaces/IOrders.java
@@ -2,15 +2,16 @@ package com.kateringapp.backend.controllers.interfaces;
 
 import com.kateringapp.backend.dtos.OrderDTO;
 import com.kateringapp.backend.dtos.criteria.OrderCriteria;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 import java.util.List;
 
 public interface IOrders {
 
-    OrderDTO createOrder(OrderDTO orderDTO);
+    OrderDTO createOrder(OrderDTO orderDTO, Jwt jwt);
     void deleteOrder(Long id);
     OrderDTO getOrder(Long id);
-    List<OrderDTO> getOrders(OrderCriteria orderCriteria);
+    List<OrderDTO> getOrders(OrderCriteria orderCriteria, Jwt jwt);
     OrderDTO updateOrder(Long id, OrderDTO orderDTO);
 
 }

--- a/backend/src/main/java/com/kateringapp/backend/dtos/MealCreateDTO.java
+++ b/backend/src/main/java/com/kateringapp/backend/dtos/MealCreateDTO.java
@@ -5,6 +5,7 @@ import lombok.Data;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.UUID;
 
 @Data
 @Builder
@@ -20,5 +21,5 @@ public class MealCreateDTO {
 
     List<String> ingredients;
 
-    Long cateringFirmId;
+    UUID cateringFirmId;
 }

--- a/backend/src/main/java/com/kateringapp/backend/dtos/OrderDTO.java
+++ b/backend/src/main/java/com/kateringapp/backend/dtos/OrderDTO.java
@@ -3,19 +3,24 @@ package com.kateringapp.backend.dtos;
 import com.kateringapp.backend.entities.order.OrderStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 @Builder
-public record OrderDTO(Long id,
-                       @NotNull
-                       List<Long> mealIds,
-                       Long clientId,
-                       String opinion,
-                       BigDecimal totalPrice,
-                       int rate,
-                       OrderStatus orderStatus,
-                       String startingAddress,
-                       String destinationAddress) {
+@Setter
+@Getter
+public class OrderDTO {
+
+    private Long id;
+    @NotNull
+    private List<Long> mealIds;
+    private String opinion;
+    private BigDecimal totalPrice;
+    private int rate;
+    private OrderStatus orderStatus;
+    private String startingAddress;
+    private String destinationAddress;
 }

--- a/backend/src/main/java/com/kateringapp/backend/dtos/criteria/OrderCriteria.java
+++ b/backend/src/main/java/com/kateringapp/backend/dtos/criteria/OrderCriteria.java
@@ -6,6 +6,5 @@ public record OrderCriteria(Integer minRate,
                             Integer maxRate,
                             OrderStatus orderStatus,
                             String startingAddress,
-                            String destinationAddress,
-                            Long clientId) {
+                            String destinationAddress) {
 }

--- a/backend/src/main/java/com/kateringapp/backend/entities/CateringFirmData.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/CateringFirmData.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Data
@@ -18,7 +19,7 @@ import java.util.List;
 public class CateringFirmData {
 
     @Id
-    private Long cateringFirmId;
+    private UUID cateringFirmId;
 
     private String info;
 

--- a/backend/src/main/java/com/kateringapp/backend/entities/client/Client.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/client/Client.java
@@ -2,9 +2,11 @@ package com.kateringapp.backend.entities.client;
 
 import lombok.Getter;
 
+import java.util.UUID;
+
 @Getter
 public class Client {
 
-    Long id;
+    UUID id;
 
 }

--- a/backend/src/main/java/com/kateringapp/backend/entities/order/Order.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/order/Order.java
@@ -10,6 +10,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -24,6 +25,8 @@ public class Order {
     private Long id;
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
+
+    private UUID clientId;
     private String opinion;
     private int rate;
     private String startingAddress;

--- a/backend/src/main/java/com/kateringapp/backend/mappers/OrderMapper.java
+++ b/backend/src/main/java/com/kateringapp/backend/mappers/OrderMapper.java
@@ -44,19 +44,19 @@ public class OrderMapper implements IOrderMapper {
 
     @Override
     public Order mapDTOToEntity(OrderDTO orderDTO) {
-        List<Meal> meals = mealRepository.findAllById(orderDTO.mealIds());
+        List<Meal> meals = mealRepository.findAllById(orderDTO.getMealIds());
 
-        if (orderDTO.mealIds().size() != meals.size()){
+        if (orderDTO.getMealIds().size() != meals.size()){
             throw new MealNotFoundException();
         }
 
         return Order.builder()
-                .rate(orderDTO.rate())
-                .opinion(orderDTO.opinion())
-                .rate(orderDTO.rate())
-                .orderStatus(orderDTO.orderStatus())
-                .startingAddress(orderDTO.startingAddress())
-                .destinationAddress(orderDTO.destinationAddress())
+                .rate(orderDTO.getRate())
+                .opinion(orderDTO.getOpinion())
+                .rate(orderDTO.getRate())
+                .orderStatus(orderDTO.getOrderStatus())
+                .startingAddress(orderDTO.getStartingAddress())
+                .destinationAddress(orderDTO.getDestinationAddress())
                 .meals(meals)
                 .build();
     }

--- a/backend/src/main/java/com/kateringapp/backend/repositories/CateringFirmDataRepository.java
+++ b/backend/src/main/java/com/kateringapp/backend/repositories/CateringFirmDataRepository.java
@@ -4,7 +4,9 @@ import com.kateringapp.backend.entities.CateringFirmData;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 @Repository
 public interface CateringFirmDataRepository extends JpaRepository<CateringFirmData, Long> {
-    CateringFirmData findByCateringFirmId(Long cateringFirmId);
+    CateringFirmData findByCateringFirmId(UUID cateringFirmId);
 }

--- a/backend/src/main/java/com/kateringapp/backend/services/OrderService.java
+++ b/backend/src/main/java/com/kateringapp/backend/services/OrderService.java
@@ -2,18 +2,25 @@ package com.kateringapp.backend.services;
 
 import com.kateringapp.backend.dtos.OrderDTO;
 import com.kateringapp.backend.dtos.criteria.OrderCriteria;
+import com.kateringapp.backend.entities.Meal;
 import com.kateringapp.backend.entities.order.Order;
 import com.kateringapp.backend.entities.order.OrderStatus;
+import com.kateringapp.backend.exceptions.meal.MealNotFoundException;
 import com.kateringapp.backend.exceptions.order.OrderNotFoundException;
 import com.kateringapp.backend.mappers.interfaces.IOrderMapper;
 import com.kateringapp.backend.repositories.IOrderRepository;
+import com.kateringapp.backend.repositories.MealRepository;
 import com.kateringapp.backend.services.interfaces.IOrderService;
 import com.kateringapp.backend.specifications.OrderSpecification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -21,10 +28,16 @@ public class OrderService implements IOrderService {
 
     private final IOrderMapper orderMapper;
     private final IOrderRepository orderRepository;
+    private final MealRepository mealRepository;
 
     @Override
-    public OrderDTO createOrder(OrderDTO orderDTO) {
+    public OrderDTO createOrder(OrderDTO orderDTO, Jwt jwt) {
+
+        UUID userId = UUID.fromString(jwt.getSubject());
+
         Order order = orderMapper.mapDTOToEntity(orderDTO);
+        order.setClientId(userId);
+
         order.setOrderStatus(OrderStatus.PENDING);
 
         order = orderRepository.save(order);
@@ -48,13 +61,25 @@ public class OrderService implements IOrderService {
     }
 
     @Override
-    public List<OrderDTO> getOrders(OrderCriteria orderCriteria) {
-        Specification<Order> orderSpecification = OrderSpecification.matchesCriteria(orderCriteria);
+    public List<OrderDTO> getOrders(OrderCriteria orderCriteria, Jwt jwt) {
 
-        return orderRepository.findAll(orderSpecification)
+        UUID userId = UUID.fromString(jwt.getSubject());
+        Map<String, Object> claims = jwt.getClaims();
+
+        Specification<Order> orderSpecification = OrderSpecification.matchesCriteria(orderCriteria, userId);
+
+        List<OrderDTO> orderDTOList = orderRepository.findAll(orderSpecification)
                 .stream()
                 .map(orderMapper::mapEntityToDTO)
                 .toList();
+
+        // Jeżeli użytkownik to firma kateringowa to z dto trzeba wywalić posiłki, które nie należą do tej firmy
+        List<String> roles  = (List<String>) ((Map<String, Object>) claims.get("realm_access")).get("roles");
+        if(roles.contains("catering-firm")) {
+            removeUnnecessaryMeals(orderDTOList, userId);
+        }
+
+        return orderDTOList;
     }
 
     @Override
@@ -68,5 +93,21 @@ public class OrderService implements IOrderService {
         return orderMapper
                 .mapEntityToDTO(orderRepository
                         .save(updatedOrder));
+    }
+
+    private void removeUnnecessaryMeals(List<OrderDTO> orderDTOS, UUID cateringFirmId) {
+        orderDTOS.forEach(orderDTO -> {
+            // Filter mealIds to retain only those belonging to the specified CateringFirm
+            List<Long> filteredMealIds = orderDTO.getMealIds().stream()
+                    .filter(mealId -> {
+                        Meal meal = mealRepository.findById(mealId)
+                                .orElseThrow(MealNotFoundException::new);
+                        return meal.getCateringFirmData().getCateringFirmId().equals(cateringFirmId);
+                    })
+                    .toList();
+
+            // Replace the existing mealIds with the filtered list
+            orderDTO.setMealIds(filteredMealIds);
+        });
     }
 }

--- a/backend/src/main/java/com/kateringapp/backend/services/interfaces/IOrderService.java
+++ b/backend/src/main/java/com/kateringapp/backend/services/interfaces/IOrderService.java
@@ -2,17 +2,18 @@ package com.kateringapp.backend.services.interfaces;
 
 import com.kateringapp.backend.dtos.OrderDTO;
 import com.kateringapp.backend.dtos.criteria.OrderCriteria;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 import java.util.List;
 
 public interface IOrderService {
-    OrderDTO createOrder(OrderDTO orderDTO);
+    OrderDTO createOrder(OrderDTO orderDTO, Jwt jwt);
 
     void deleteOrder(Long id);
 
     OrderDTO getOrder(Long id);
 
-    List<OrderDTO> getOrders(OrderCriteria orderCriteria);
+    List<OrderDTO> getOrders(OrderCriteria orderCriteria, Jwt jwt);
 
     OrderDTO updateOrder(Long id, OrderDTO orderDTO);
 }

--- a/backend/src/main/java/com/kateringapp/backend/specifications/OrderSpecification.java
+++ b/backend/src/main/java/com/kateringapp/backend/specifications/OrderSpecification.java
@@ -1,20 +1,24 @@
 package com.kateringapp.backend.specifications;
 
 import com.kateringapp.backend.dtos.criteria.OrderCriteria;
+import com.kateringapp.backend.entities.Meal;
 import com.kateringapp.backend.entities.order.Order;
+import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Predicate;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Function;
 
 public class OrderSpecification {
 
-    public static Specification<Order> matchesCriteria(OrderCriteria criteria) {
+    public static Specification<Order> matchesCriteria(OrderCriteria criteria, UUID userId) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
 
+            // Existing criteria
             addPredicateIfNotNull(predicates, criteria.minRate(), minRate ->
                     cb.greaterThanOrEqualTo(root.get("rate"), minRate));
 
@@ -24,15 +28,25 @@ public class OrderSpecification {
             addPredicateIfNotNull(predicates, criteria.orderStatus(), orderStatus ->
                     cb.equal(root.get("orderStatus"), orderStatus));
 
-            addPredicateIfNotNull(predicates, criteria.clientId(), clientId ->
-                    cb.equal(root.get("client").get("id"), clientId));
-
             addPredicateIfNotNull(predicates, criteria.startingAddress(), startingAddress ->
                     cb.like(root.get("startingAddress"), "%" + startingAddress + "%"));
 
             addPredicateIfNotNull(predicates, criteria.destinationAddress(), destinationAddress ->
                     cb.like(root.get("destinationAddress"), "%" + destinationAddress + "%"));
 
+            // New logic to match orders by clientId OR meals.cateringFirmData.cateringFirmId
+            Predicate byClientId = cb.equal(root.get("clientId"), userId);
+
+            Join<Order, Meal> mealJoin = root.join("meals");
+            Predicate byCateringFirmId = cb.equal(mealJoin.join("cateringFirmData").get("cateringFirmId"), userId);
+
+            // Combine the two with OR
+            Predicate combined = cb.or(byClientId, byCateringFirmId);
+
+            // Add combined predicate to the list
+            predicates.add(combined);
+
+            // Combine all predicates with AND
             return cb.and(predicates.toArray(new Predicate[0]));
         };
     }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- Tworzenie tabeli 'catering_firm_data' z ręcznie przypisywanym ID
 CREATE TABLE IF NOT EXISTS catering_firm_data (
-                                                  catering_firm_id BIGINT PRIMARY KEY,  -- Ręczne przypisywanie ID
+                                                  catering_firm_id UUID PRIMARY KEY,  -- Ręczne przypisywanie ID
                                                   name VARCHAR(255) NOT NULL,
     info TEXT,
     logo BYTEA
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS ingredient_allergen (
 CREATE TABLE IF NOT EXISTS orders (
     id BIGINT PRIMARY KEY,
     order_status VARCHAR(50) NOT NULL,
+    client_id UUID,
     opinion TEXT,
     rate INT NOT NULL,
     starting_address VARCHAR(255) NOT NULL,
@@ -43,7 +44,7 @@ CREATE TABLE IF NOT EXISTS meal (
     price INT NOT NULL,
     description TEXT NOT NULL,
     photo BYTEA,
-    catering_firm_id BIGINT,
+    catering_firm_id UUID,
     FOREIGN KEY (catering_firm_id) REFERENCES catering_firm_data(catering_firm_id)
     );
 
@@ -63,7 +64,7 @@ CREATE TABLE IF NOT EXISTS delivery_type (
 
 -- Tworzenie tabeli 'catering_firm_data_delivery_type' (relacja wiele do wielu)
 CREATE TABLE IF NOT EXISTS catering_firm_data_delivery_type (
-                                                                catering_firm_id BIGINT,
+                                                                catering_firm_id UUID,
                                                                 delivery_type_id BIGINT,
                                                                 PRIMARY KEY (catering_firm_id, delivery_type_id),
     FOREIGN KEY (catering_firm_id) REFERENCES catering_firm_data(catering_firm_id),
@@ -81,9 +82,9 @@ CREATE TABLE IF NOT EXISTS meal_ingredients (
 -- Wstawianie danych do tabeli 'catering_firm_data'
 INSERT INTO catering_firm_data (catering_firm_id, name, info, logo)
 VALUES
-    (1, 'Italian Delights Catering', 'Italian cuisine with a variety of pasta and pizza options', null),
-    (2, 'Healthy Bites', 'Fresh, organic, and healthy meals', null),
-    (3, 'Smoothie Masters', 'Delicious smoothies and acai bowls', null);
+    ('6c84fb95-12c4-11ec-82a8-0242ac130005', 'Italian Delights Catering', 'Italian cuisine with a variety of pasta and pizza options', null),
+    ('6c84fb95-12c4-11ec-82a8-0242ac130006', 'Healthy Bites', 'Fresh, organic, and healthy meals', null),
+    ('919b0f69-766e-4f51-a36c-5e9e643385cd', 'Smoothie Masters', 'Delicious smoothies and acai bowls', null);
 
 -- Wstawianie danych do tabeli 'ingredient'
 INSERT INTO ingredient (ingredient_id, name)
@@ -138,12 +139,12 @@ VALUES
 -- Wstawianie danych do tabeli 'meal'
 INSERT INTO meal (meal_id, name, price, description, photo, catering_firm_id)
 VALUES
-    (101, 'Pasta Carbonara', 12, 'A classic Italian pasta dish with creamy sauce and pancetta.', null, 1),
-    (102, 'Margherita Pizza', 10, 'A simple pizza with tomato, mozzarella, and basil.', null, 1),
-    (103, 'Grilled Chicken Salad', 8, 'A healthy salad with grilled chicken, fresh greens, and vinaigrette.', null, 2),
-    (104, 'Vegan Burger', 7, 'A plant-based burger with a side of fries.', null, 2),
-    (105, 'Tropical Smoothie', 5, 'A refreshing smoothie made with pineapple, mango, and coconut milk.', null, 3),
-    (106, 'Acai Bowl', 6, 'A smoothie bowl topped with granola, fruits, and honey.', null, 3);
+    (101, 'Pasta Carbonara', 12, 'A classic Italian pasta dish with creamy sauce and pancetta.', null, '6c84fb95-12c4-11ec-82a8-0242ac130005'),
+    (102, 'Margherita Pizza', 10, 'A simple pizza with tomato, mozzarella, and basil.', null, '6c84fb95-12c4-11ec-82a8-0242ac130005'),
+    (103, 'Grilled Chicken Salad', 8, 'A healthy salad with grilled chicken, fresh greens, and vinaigrette.', null, '6c84fb95-12c4-11ec-82a8-0242ac130006'),
+    (104, 'Vegan Burger', 7, 'A plant-based burger with a side of fries.', null, '6c84fb95-12c4-11ec-82a8-0242ac130005'),
+    (105, 'Tropical Smoothie', 5, 'A refreshing smoothie made with pineapple, mango, and coconut milk.', null, '6c84fb95-12c4-11ec-82a8-0242ac130006'),
+    (106, 'Acai Bowl', 6, 'A smoothie bowl topped with granola, fruits, and honey.', null, '6c84fb95-12c4-11ec-82a8-0242ac130006');
 
 -- Wstawianie danych do tabeli 'delivery_type'
 INSERT INTO delivery_type (delivery_type_id, delivery_type)
@@ -154,16 +155,16 @@ VALUES
 -- Powiązania dla 'catering_firm_data_delivery_type'
 INSERT INTO catering_firm_data_delivery_type (catering_firm_id, delivery_type_id)
 VALUES
-    (1, 1),  -- Italian Delights Catering: Home Delivery
-    (1, 2),  -- Italian Delights Catering: Pick-Up
-    (2, 1),  -- Healthy Bites: Home Delivery
-    (3, 1);  -- Smoothie Masters: Home Delivery
+    ('919b0f69-766e-4f51-a36c-5e9e643385cd', 1),  -- Italian Delights Catering: Home Delivery
+    ('919b0f69-766e-4f51-a36c-5e9e643385cd', 2),  -- Italian Delights Catering: Pick-Up
+    ('919b0f69-766e-4f51-a36c-5e9e643385cd', 1),  -- Healthy Bites: Home Delivery
+    ('919b0f69-766e-4f51-a36c-5e9e643385cd', 1);  -- Smoothie Masters: Home Delivery
 
-INSERT INTO orders (id, order_status, opinion, rate, starting_address, destination_address)
+INSERT INTO orders (id, order_status, client_id, opinion, rate, starting_address, destination_address)
 VALUES
-    (101, 'PENDING', 'Good service', 5, '123 Starting St', '789 Destination Ave'),
-    (102, 'COMPLETED', 'Quick delivery', 4, '456 Another St', '101 Another Ave'),
-    (103, 'CANCELLED', 'Not delivered on time', 2, '789 Late St', '111 Final Ave');
+    (101, 'PENDING', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'Good service', 5, '123 Starting St', '789 Destination Ave'),
+    (102, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'Quick delivery', 4, '456 Another St', '101 Another Ave'),
+    (103, 'CANCELLED', '6c84fb95-12c4-11ec-82a8-0242ac130003', 'Not delivered on time', 2, '789 Late St', '111 Final Ave');
 
 -- Pasta Carbonara (Meal ID: 1) - składniki: Wheat Flour (ID: 3), Milk (ID: 1), Egg Whites (ID: 5)
 INSERT INTO meal_ingredients (meal_id, ingredient_id) VALUES (101, 3);

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -155,10 +155,10 @@ VALUES
 -- Powiązania dla 'catering_firm_data_delivery_type'
 INSERT INTO catering_firm_data_delivery_type (catering_firm_id, delivery_type_id)
 VALUES
-    ('919b0f69-766e-4f51-a36c-5e9e643385cd', 1),  -- Italian Delights Catering: Home Delivery
-    ('919b0f69-766e-4f51-a36c-5e9e643385cd', 2),  -- Italian Delights Catering: Pick-Up
-    ('919b0f69-766e-4f51-a36c-5e9e643385cd', 1),  -- Healthy Bites: Home Delivery
-    ('919b0f69-766e-4f51-a36c-5e9e643385cd', 1);  -- Smoothie Masters: Home Delivery
+    ('6c84fb95-12c4-11ec-82a8-0242ac130005', 1),  -- Italian Delights Catering: Home Delivery
+    ('6c84fb95-12c4-11ec-82a8-0242ac130005', 2),  -- Italian Delights Catering: Pick-Up
+    ('6c84fb95-12c4-11ec-82a8-0242ac130006', 1),  -- Healthy Bites: Home Delivery
+    ('6c84fb95-12c4-11ec-82a8-0242ac130006', 2);  -- Smoothie Masters: Home Delivery
 
 INSERT INTO orders (id, order_status, client_id, opinion, rate, starting_address, destination_address)
 VALUES

--- a/backend/src/main/resources/get-token.http
+++ b/backend/src/main/resources/get-token.http
@@ -8,6 +8,16 @@ grant_type=password&
 username=janedoe@gmail.com&
 password=password
 
+### Token klienta
+POST http://localhost:8081/realms/kateringapp/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+client_id=KateringAppClientBackend&
+client_secret=fZWsuYBEJuB2vu0625BbQcpCIVAQa1k5&
+grant_type=password&
+username=johndoe@gmail.com&
+password=password
+
 ### Token firmy kateringowej
 POST http://localhost:8081/realms/kateringapp/protocol/openid-connect/token
 Content-Type: application/x-www-form-urlencoded
@@ -16,4 +26,14 @@ client_id=KateringAppClientBackend&
 client_secret=fZWsuYBEJuB2vu0625BbQcpCIVAQa1k5&
 grant_type=password&
 username=firm1@gmail.com&
+password=password
+
+### Token firmy kateringowej
+POST http://localhost:8081/realms/kateringapp/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+client_id=KateringAppClientBackend&
+client_secret=fZWsuYBEJuB2vu0625BbQcpCIVAQa1k5&
+grant_type=password&
+username=firm3@gmail.com&
 password=password

--- a/backend/src/test/java/com/kateringapp/backend/MealsUnitTest.java
+++ b/backend/src/test/java/com/kateringapp/backend/MealsUnitTest.java
@@ -17,6 +17,7 @@ import org.mockito.*;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,13 +42,16 @@ class MealsUnitTest {
     private Meal meal;
     private MealCreateDTO mealCreateDTO;
     private CateringFirmData cateringFirmData;
+    private UUID cateringFirmId;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
 
+        cateringFirmId = UUID.randomUUID();
+
         cateringFirmData = CateringFirmData.builder()
-                .cateringFirmId(1L)
+                .cateringFirmId(cateringFirmId)
                 .build();
 
         meal = Meal.builder()
@@ -62,13 +66,14 @@ class MealsUnitTest {
                 .name("Sample Meal")
                 .price(BigDecimal.valueOf(100))
                 .description("Delicious sample meal")
-                .cateringFirmId(1L)
+                .cateringFirmId(cateringFirmId)
                 .build();
     }
 
     @Test
     void createMeal() {
-        when(cateringFirmDataRepository.findByCateringFirmId(1L)).thenReturn(cateringFirmData);
+
+        when(cateringFirmDataRepository.findByCateringFirmId(cateringFirmId)).thenReturn(cateringFirmData);
         when(mealMapper.mapDTOToEntity(mealCreateDTO, cateringFirmData)).thenReturn(meal);
         when(mealRepository.save(meal)).thenReturn(meal);
         when(mealMapper.mapEntityToDTO(meal)).thenReturn(MealGetDTO.builder()

--- a/backend/src/test/java/com/kateringapp/backend/data/TestDataProvider.java
+++ b/backend/src/test/java/com/kateringapp/backend/data/TestDataProvider.java
@@ -20,7 +20,6 @@ public class TestDataProvider {
                 .startingAddress("aaa")
                 .destinationAddress("bbb")
                 .opinion("good")
-                .clientId(1L)
                 .mealIds(Collections.emptyList())
                 .build();
     }

--- a/keycloak/realm.json
+++ b/keycloak/realm.json
@@ -126,6 +126,27 @@
       "realmRoles": [
         "catering-firm", "default-roles-kateringapp"
       ]
+    },
+    {
+      "id": "919b0f69-766e-4f51-a36c-5e9e643385cd",
+      "enabled":true,
+      "createdTimestamp":"1701385200000",
+      "username": "firm3@gmail.com",
+      "email": "firm3@gmail.com",
+      "attributes" : {
+        "isCateringFirm": true,
+        "address": "1234 Main St",
+        "phoneNumber": "123-456-7890"
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password"
+        }
+      ],
+      "realmRoles": [
+        "catering-firm", "default-roles-kateringapp"
+      ]
     }
   ],
   "roles": {


### PR DESCRIPTION
To co zrobiłem:
-  firma kateringowa powinna mieć dostęp do podglądu tylko do należących do niej zamówień
- klient powinien widzieć tylko swoje własne zamówienia

to jest tymczasowa naprawa bo firma kateringowa powinna mieć swój odrębny controller - teraz jak się wyciąga zamówienie to ono zawiera posiłki różnych firm, więc je musiałem ręcznie usuwać z dto przed zwróceniem.

Czego nie zrobiłem:
w zwracanym z zamówienia api powinno być info o firmie kateringowej i kliencie - nie mamy serwisu do wyciągania info o użytkownikach, więc nie ma sensu teraz takich rzeczy implementować, szczególnie że zamówienie ma kilka posiłków, a każdy posiłek to może być inna firma

firma kateringowa powinna mieć dostęp do  wszelkich modyfikacji tylko do należących do niej zamówień - to tak samo jest niemożliwe przy tym api które jest teraz bo UPDATE jest na całe zamówienie, a zamówienie może zawierać posiłki od wielu firm

imo to jest nie do zrobienia na teraz - ja na pewno nie zamierzam tego na wariata teraz poprawiać