### PR TITLE
Poprawienie wyświetlania ceny w meal list

### DIFF
--- a/frontend/src/app/features/meal/meal-form/meal-form.component.ts
+++ b/frontend/src/app/features/meal/meal-form/meal-form.component.ts
@@ -86,7 +86,7 @@ export default class MealFormComponent
 
     const payload = {
       ...this.meal,
-      price: this.meal.price * 100,
+      price: this.meal.price,
     };
 
     this.mealService.createMeal(payload).subscribe({

--- a/frontend/src/app/features/meal/meal-list/meal-list.component.html
+++ b/frontend/src/app/features/meal/meal-list/meal-list.component.html
@@ -28,7 +28,7 @@
       <td class="px-4 py-2 border border-gray-300">{{ i + 1 }}</td>
 
       <td class="px-4 py-2 border border-gray-300">{{ meal.name }}</td>
-      <td class="px-4 py-2 border border-gray-300">{{ meal.price / 100 }}</td>
+      <td class="px-4 py-2 border border-gray-300">{{ meal.price }} PLN</td>
       <td class="px-4 py-2 border border-gray-300">{{ meal.description }}</td>
       <td class="px-4 py-2 border border-gray-300">
         <img [src]="meal.photo" alt="{{ meal.name }}" class="w-16 h-16" />


### PR DESCRIPTION
Jako że api przyjmuje decimal nie rozumiem czemu mnożymy cene razy 100 przy wysyłaniu / dzielimy na 100 przy pobieraniu