### PR TITLE
68 be endpoint dla wykresu zysków

### DIFF
--- a/backend/src/main/java/com/kateringapp/backend/configurations/SpringContextRetriever.java
+++ b/backend/src/main/java/com/kateringapp/backend/configurations/SpringContextRetriever.java
@@ -1,0 +1,22 @@
+package com.kateringapp.backend.configurations;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class SpringContextRetriever {
+
+    public UUID getCurrentUserIdFromJwt() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated() && authentication.getPrincipal() instanceof Jwt jwt) {
+            return UUID.fromString(jwt.getClaimAsString("sub"));
+        }
+
+        return null;
+    }
+}

--- a/backend/src/main/java/com/kateringapp/backend/controllers/MealsController.java
+++ b/backend/src/main/java/com/kateringapp/backend/controllers/MealsController.java
@@ -1,7 +1,7 @@
 package com.kateringapp.backend.controllers;
 
 import com.kateringapp.backend.dtos.MealCreateDTO;
-import com.kateringapp.backend.dtos.MealCriteria;
+import com.kateringapp.backend.dtos.criteria.MealCriteria;
 import com.kateringapp.backend.dtos.MealGetDTO;
 import com.kateringapp.backend.services.MealsService;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/kateringapp/backend/controllers/StatisticsController.java
+++ b/backend/src/main/java/com/kateringapp/backend/controllers/StatisticsController.java
@@ -1,0 +1,24 @@
+package com.kateringapp.backend.controllers;
+
+import com.kateringapp.backend.dtos.OrderStatisticsDTO;
+import com.kateringapp.backend.dtos.criteria.OrderStatisticCriteria;
+import com.kateringapp.backend.services.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stats")
+public class StatisticsController {
+    private final StatisticsService statisticsService;
+
+    @GetMapping
+    public List<OrderStatisticsDTO> getStatisticsChart(@ModelAttribute OrderStatisticCriteria orderStatisticCriteria){
+        return statisticsService.getOrderStatistics(orderStatisticCriteria);
+    }
+}

--- a/backend/src/main/java/com/kateringapp/backend/dtos/OrderStatisticsDTO.java
+++ b/backend/src/main/java/com/kateringapp/backend/dtos/OrderStatisticsDTO.java
@@ -1,0 +1,16 @@
+package com.kateringapp.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class OrderStatisticsDTO {
+    Date date;
+    BigDecimal sale;
+}

--- a/backend/src/main/java/com/kateringapp/backend/dtos/criteria/MealCriteria.java
+++ b/backend/src/main/java/com/kateringapp/backend/dtos/criteria/MealCriteria.java
@@ -1,4 +1,4 @@
-package com.kateringapp.backend.dtos;
+package com.kateringapp.backend.dtos.criteria;
 
 import lombok.Builder;
 import lombok.Data;

--- a/backend/src/main/java/com/kateringapp/backend/dtos/criteria/OrderStatisticCriteria.java
+++ b/backend/src/main/java/com/kateringapp/backend/dtos/criteria/OrderStatisticCriteria.java
@@ -1,0 +1,15 @@
+package com.kateringapp.backend.dtos.criteria;
+
+import com.kateringapp.backend.entities.StatisticsPeriod;
+import lombok.Builder;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@Builder
+public class OrderStatisticCriteria {
+    Timestamp startDate;
+    Timestamp endDate;
+    StatisticsPeriod statisticsPeriod;
+}

--- a/backend/src/main/java/com/kateringapp/backend/entities/CateringFirmData.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/CateringFirmData.java
@@ -35,7 +35,7 @@ public class CateringFirmData {
     private List<DeliveryType> deliveryOptions;
 
     @Lob
-    @Column(name = "logo", columnDefinition = "BLOB")
+    @Column(name = "logo", columnDefinition = "BYTEA")
     private byte[] logo;
 
     @OneToMany

--- a/backend/src/main/java/com/kateringapp/backend/entities/Meal.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/Meal.java
@@ -32,7 +32,7 @@ public class Meal {
     private String description;
 
     @Lob
-    @Column(name = "photo", columnDefinition = "BLOB")
+    @Column(name = "photo", columnDefinition = "BYTEA")
     private byte[] photo;
 
     @ManyToOne

--- a/backend/src/main/java/com/kateringapp/backend/entities/StatisticsPeriod.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/StatisticsPeriod.java
@@ -1,0 +1,5 @@
+package com.kateringapp.backend.entities;
+
+public enum StatisticsPeriod {
+    WEEK, MONTH, YEAR
+}

--- a/backend/src/main/java/com/kateringapp/backend/entities/order/Order.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/order/Order.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
+import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -39,5 +41,7 @@ public class Order {
             inverseJoinColumns = @JoinColumn(name = "meal_id")
     )
     private List<Meal> meals = new ArrayList<>();
+    private Timestamp completedAt;
+    private BigDecimal totalPrice;
 
 }

--- a/backend/src/main/java/com/kateringapp/backend/mappers/OrderMapper.java
+++ b/backend/src/main/java/com/kateringapp/backend/mappers/OrderMapper.java
@@ -3,6 +3,7 @@ package com.kateringapp.backend.mappers;
 import com.kateringapp.backend.dtos.OrderDTO;
 import com.kateringapp.backend.entities.Meal;
 import com.kateringapp.backend.entities.order.Order;
+import com.kateringapp.backend.entities.order.OrderStatus;
 import com.kateringapp.backend.exceptions.meal.MealNotFoundException;
 import com.kateringapp.backend.mappers.interfaces.IOrderMapper;
 import com.kateringapp.backend.repositories.MealRepository;
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 
 @Component
@@ -25,17 +28,13 @@ public class OrderMapper implements IOrderMapper {
                 .map(Meal::getMealId)
                 .toList();
 
-        BigDecimal totalPrice = order.getMeals()
-                .stream()
-                .map(Meal::getPrice)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         return OrderDTO.builder()
                 .id(order.getId())
                 .opinion(order.getOpinion())
                 .orderStatus(order.getOrderStatus())
                 .rate(order.getRate())
-                .totalPrice(totalPrice)
+                .totalPrice(order.getTotalPrice())
                 .mealIds(mealIds)
                 .startingAddress(order.getStartingAddress())
                 .destinationAddress(order.getDestinationAddress())
@@ -50,15 +49,28 @@ public class OrderMapper implements IOrderMapper {
             throw new MealNotFoundException();
         }
 
-        return Order.builder()
+        BigDecimal totalPrice = meals
+                .stream()
+                .map(Meal::getPrice)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        Order order = Order.builder()
                 .rate(orderDTO.getRate())
                 .opinion(orderDTO.getOpinion())
                 .rate(orderDTO.getRate())
                 .orderStatus(orderDTO.getOrderStatus())
                 .startingAddress(orderDTO.getStartingAddress())
                 .destinationAddress(orderDTO.getDestinationAddress())
+                .totalPrice(totalPrice)
                 .meals(meals)
                 .build();
+
+        if(orderDTO.getOrderStatus() == OrderStatus.COMPLETED){
+            order.setCompletedAt(Timestamp.from(Instant.now()));
+        }
+
+        return order;
+
     }
 
 }

--- a/backend/src/main/java/com/kateringapp/backend/repositories/IOrderRepository.java
+++ b/backend/src/main/java/com/kateringapp/backend/repositories/IOrderRepository.java
@@ -13,4 +13,6 @@ public interface IOrderRepository extends JpaRepository<Order, Long>,
         JpaSpecificationExecutor<Order> {
 
     List<Order> findOrdersByMealsContaining(Meal meal);
+
+
 }

--- a/backend/src/main/java/com/kateringapp/backend/services/OrderService.java
+++ b/backend/src/main/java/com/kateringapp/backend/services/OrderService.java
@@ -19,8 +19,6 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -95,7 +93,6 @@ public class OrderService implements IOrderService {
 
     private void removeUnnecessaryMeals(List<OrderDTO> orderDTOS, UUID cateringFirmId) {
         orderDTOS.forEach(orderDTO -> {
-            // Filter mealIds to retain only those belonging to the specified CateringFirm
             List<Long> filteredMealIds = orderDTO.getMealIds().stream()
                     .filter(mealId -> {
                         Meal meal = mealRepository.findById(mealId)
@@ -104,7 +101,6 @@ public class OrderService implements IOrderService {
                     })
                     .toList();
 
-            // Replace the existing mealIds with the filtered list
             orderDTO.setMealIds(filteredMealIds);
         });
     }

--- a/backend/src/main/java/com/kateringapp/backend/services/StatisticsService.java
+++ b/backend/src/main/java/com/kateringapp/backend/services/StatisticsService.java
@@ -1,0 +1,78 @@
+package com.kateringapp.backend.services;
+
+import com.kateringapp.backend.configurations.SpringContextRetriever;
+import com.kateringapp.backend.dtos.OrderStatisticsDTO;
+import com.kateringapp.backend.dtos.criteria.OrderStatisticCriteria;
+import com.kateringapp.backend.entities.QMeal;
+import com.kateringapp.backend.entities.order.OrderStatus;
+import com.kateringapp.backend.entities.order.QOrder;
+import com.kateringapp.backend.services.interfaces.IStatistics;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static com.querydsl.core.types.dsl.Expressions.dateTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService implements IStatistics {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+    private final SpringContextRetriever springContextRetriever;
+
+    @Override
+    public List<OrderStatisticsDTO> getOrderStatistics(OrderStatisticCriteria criteria) {
+        QOrder qOrder = QOrder.order;
+        QMeal qMeal = QMeal.meal;
+        UUID cateringFirmId = springContextRetriever.getCurrentUserIdFromJwt();
+
+        BooleanBuilder conditions = new BooleanBuilder();
+        conditions.and(qMeal.cateringFirmData.cateringFirmId.eq(cateringFirmId))
+                .and(qOrder.orderStatus.eq(OrderStatus.COMPLETED));
+
+        if(criteria.getStatisticsPeriod() == null) {
+            if (criteria.getStartDate() != null) {
+                conditions.and(qOrder.completedAt.goe(criteria.getStartDate()));
+            }
+            if (criteria.getEndDate() != null) {
+                conditions.and(qOrder.completedAt.loe(criteria.getEndDate()));
+            }
+        }
+        else{
+            switch(criteria.getStatisticsPeriod()){
+                case WEEK -> conditions.and(qOrder.completedAt.goe(Timestamp.from(Instant.from(LocalDate.now().minusWeeks(1)))));
+                case MONTH -> conditions.and(qOrder.completedAt.goe(Timestamp.from(Instant.from(LocalDate.now().minusMonths(1)))));
+                case YEAR -> conditions.and(qOrder.completedAt.goe(Timestamp.from(Instant.from(LocalDate.now().minusYears(1)))));
+            }
+        }
+
+        JPAQuery<OrderStatisticsDTO> query = new JPAQuery<>(entityManager)
+                .select(
+                        Projections.constructor(
+                                OrderStatisticsDTO.class,
+                                dateTemplate(Date.class, "CAST({0} AS DATE)", qOrder.completedAt).as("date"),
+                                qMeal.price.sum().as("sale")
+                        )
+                )
+                .from(qOrder)
+                .join(qOrder.meals, qMeal)
+                .where(conditions)
+                .groupBy(dateTemplate(String.class, "CAST({0} AS DATE)", qOrder.completedAt))
+                .orderBy(dateTemplate(String.class, "CAST({0} AS DATE)", qOrder.completedAt).asc());
+
+        return query.fetch();
+    }
+
+}

--- a/backend/src/main/java/com/kateringapp/backend/services/StatisticsService.java
+++ b/backend/src/main/java/com/kateringapp/backend/services/StatisticsService.java
@@ -18,7 +18,8 @@ import org.springframework.stereotype.Service;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 
@@ -52,9 +53,24 @@ public class StatisticsService implements IStatistics {
         }
         else{
             switch(criteria.getStatisticsPeriod()){
-                case WEEK -> conditions.and(qOrder.completedAt.goe(Timestamp.from(Instant.from(LocalDate.now().minusWeeks(1)))));
-                case MONTH -> conditions.and(qOrder.completedAt.goe(Timestamp.from(Instant.from(LocalDate.now().minusMonths(1)))));
-                case YEAR -> conditions.and(qOrder.completedAt.goe(Timestamp.from(Instant.from(LocalDate.now().minusYears(1)))));
+                case WEEK -> {
+                    Instant oneWeekAgo = LocalDateTime.now().minusWeeks(1)
+                            .atZone(ZoneId.systemDefault())
+                            .toInstant();
+                    conditions.and(qOrder.completedAt.goe(Timestamp.from(oneWeekAgo)));
+                }
+                case MONTH -> {
+                    Instant oneMonthAgo = LocalDateTime.now().minusMonths(1)
+                            .atZone(ZoneId.systemDefault())
+                            .toInstant();
+                    conditions.and(qOrder.completedAt.goe(Timestamp.from(oneMonthAgo)));
+                }
+                case YEAR -> {
+                    Instant oneYearAgo = LocalDateTime.now().minusYears(1)
+                            .atZone(ZoneId.systemDefault())
+                            .toInstant();
+                    conditions.and(qOrder.completedAt.goe(Timestamp.from(oneYearAgo)));
+                }
             }
         }
 

--- a/backend/src/main/java/com/kateringapp/backend/services/interfaces/IMeals.java
+++ b/backend/src/main/java/com/kateringapp/backend/services/interfaces/IMeals.java
@@ -1,8 +1,8 @@
-package com.kateringapp.backend.services;
+package com.kateringapp.backend.services.interfaces;
 
 
 import com.kateringapp.backend.dtos.MealCreateDTO;
-import com.kateringapp.backend.dtos.MealCriteria;
+import com.kateringapp.backend.dtos.criteria.MealCriteria;
 import com.kateringapp.backend.dtos.MealGetDTO;
 import org.springframework.security.oauth2.jwt.Jwt;
 

--- a/backend/src/main/java/com/kateringapp/backend/services/interfaces/IStatistics.java
+++ b/backend/src/main/java/com/kateringapp/backend/services/interfaces/IStatistics.java
@@ -1,0 +1,10 @@
+package com.kateringapp.backend.services.interfaces;
+
+import com.kateringapp.backend.dtos.OrderStatisticsDTO;
+import com.kateringapp.backend.dtos.criteria.OrderStatisticCriteria;
+
+import java.util.List;
+
+public interface IStatistics {
+    List<OrderStatisticsDTO> getOrderStatistics(OrderStatisticCriteria criteria);
+}

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -13,7 +13,7 @@ spring:
       settings:
         web-allow-others: true
   datasource:
-    url: jdbc:h2:mem:db
+    url: jdbc:h2:mem:db;MODE=PostgreSQL
     username: sa
     password: sa
     driverClassName: org.h2.Driver

--- a/backend/src/main/resources/application-test.yaml
+++ b/backend/src/main/resources/application-test.yaml
@@ -23,7 +23,7 @@ spring:
   h2:
     console.enabled: true # http://localhost:8080/h2-console
   datasource:
-    url: jdbc:h2:mem:db
+    url: jdbc:h2:mem:db;MODE=PostgreSQL
     username: sa
     password: sa
     driverClassName: org.h2.Driver

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -160,11 +160,29 @@ VALUES
     ('6c84fb95-12c4-11ec-82a8-0242ac130006', 1),  -- Healthy Bites: Home Delivery
     ('6c84fb95-12c4-11ec-82a8-0242ac130006', 2);  -- Smoothie Masters: Home Delivery
 
-INSERT INTO orders (id, order_status, client_id, opinion, rate, starting_address, destination_address)
+INSERT INTO orders (id, order_status, client_id, opinion, rate, starting_address, destination_address, total_price, completed_at)
 VALUES
-    (101, 'PENDING', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'Good service', 5, '123 Starting St', '789 Destination Ave'),
-    (102, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'Quick delivery', 4, '456 Another St', '101 Another Ave'),
-    (103, 'CANCELLED', '6c84fb95-12c4-11ec-82a8-0242ac130003', 'Not delivered on time', 2, '789 Late St', '111 Final Ave');
+    (101, 'PENDING', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'Good service', 5, '123 Starting St', '789 Destination Ave', 22, null),
+    (102, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'Quick delivery', 4, '456 Another St', '101 Another Ave', 15, '2024-03-28 00:00:00'::timestamp),
+    (103, 'CANCELLED', '6c84fb95-12c4-11ec-82a8-0242ac130003', 'Not delivered on time', 2, '789 Late St', '111 Final Ave', 11, null),
+    (104, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'Delicious meals!', 5, '22 Elm St', '88 Pine St', 18, '2024-03-15 12:45:00'::timestamp),
+    (105, 'COMPLETED', '919b0f69-766e-4f51-a36c-5e9e643385cd', 'Loved the smoothies!', 4, '300 Oak St', '700 Maple St', 10, '2024-03-20 15:30:00'::timestamp),
+    (106, 'PENDING', '6c84fb95-12c4-11ec-82a8-0242ac130005', 'Waiting for delivery...', 3, '55 Birch St', '66 Willow St', 12, NULL),
+    (107, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130003', 'Fast service!', 5, '99 Cedar St', '101 Oak St', 25, '2024-03-21 18:00:00'::timestamp),
+    (108, 'CANCELLED', '6c84fb95-12c4-11ec-82a8-0242ac130002', 'Had to cancel', 1, '200 Ash St', '300 Spruce St', 15, NULL),
+    (109, 'COMPLETED', '919b0f69-766e-4f51-a36c-5e9e643385cd', 'Very fresh ingredients', 4, '45 Palm St', '50 Mango St', 14, '2024-03-25 11:20:00'::timestamp),
+    (110, 'PENDING', '6c84fb95-12c4-11ec-82a8-0242ac130006', 'Looking forward to it', 4, '77 Cypress St', '99 Mahogany St', 17, NULL),
+    (111, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130003', 'Satisfying meal', 5, '33 Cherry St', '44 Chestnut St', 20, '2024-04-01 19:45:00'::timestamp),
+    (112, 'PENDING', '6c84fb95-12c4-11ec-82a8-0242ac130005', 'Late order', 2, '11 Pear St', '22 Peach St', 13, NULL),
+    (113, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'Great taste', 5, '19 Apricot St', '31 Grape St', 16, '2024-04-05 20:10:00'::timestamp),
+    (114, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130005', 'Best pizza!', 5, '21 Lime St', '42 Fig St', 22, '2024-04-10 12:00:00'::timestamp),
+    (115, 'CANCELLED', '919b0f69-766e-4f51-a36c-5e9e643385cd', 'Changed my mind', 2, '78 Plum St', '89 Orange St', 10, NULL),
+    (116, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130002', 'Good service overall', 4, '60 Strawberry St', '70 Blueberry St', 19, '2024-04-15 13:50:00'::timestamp),
+    (117, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'Healthy and tasty', 5, '88 Blackberry St', '99 Raspberry St', 18, '2024-04-20 10:30:00'::timestamp),
+    (118, 'PENDING', '6c84fb95-12c4-11ec-82a8-0242ac130006', 'Order in progress', 3, '15 Watermelon St', '25 Melon St', 14, NULL),
+    (119, 'CANCELLED', '6c84fb95-12c4-11ec-82a8-0242ac130005', 'Perfectly cooked', 5, '100 Pineapple St', '150 Banana St', 25, '2024-04-22 17:25:00'::timestamp),
+    (120, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130003', 'Loved every bite!', 5, '33 Coconut St', '44 Papaya St', 21, '2024-04-25 19:40:00'::timestamp),
+    (121, 'COMPLETED', '6c84fb95-12c4-11ec-82a8-0242ac130004', 'wooow so delicioso', 5, '88 Blackberry St', '99 Raspberry St', 18, '2024-04-20 10:30:00'::timestamp);
 
 -- Pasta Carbonara (Meal ID: 1) - składniki: Wheat Flour (ID: 3), Milk (ID: 1), Egg Whites (ID: 5)
 INSERT INTO meal_ingredients (meal_id, ingredient_id) VALUES (101, 3);
@@ -196,3 +214,75 @@ INSERT INTO order_meals (order_id, meal_id) VALUES (102, 104);
 
 INSERT INTO order_meals (order_id, meal_id) VALUES (103, 105);
 INSERT INTO order_meals (order_id, meal_id) VALUES (103, 106);
+
+-- Zamówienie 104
+INSERT INTO order_meals (order_id, meal_id) VALUES (104, 101);
+INSERT INTO order_meals (order_id, meal_id) VALUES (104, 102);
+
+-- Zamówienie 105
+INSERT INTO order_meals (order_id, meal_id) VALUES (105, 103);
+INSERT INTO order_meals (order_id, meal_id) VALUES (105, 104);
+
+-- Zamówienie 106
+INSERT INTO order_meals (order_id, meal_id) VALUES (106, 105);
+INSERT INTO order_meals (order_id, meal_id) VALUES (106, 106);
+
+-- Zamówienie 107
+INSERT INTO order_meals (order_id, meal_id) VALUES (107, 101);
+INSERT INTO order_meals (order_id, meal_id) VALUES (107, 102);
+
+-- Zamówienie 108
+INSERT INTO order_meals (order_id, meal_id) VALUES (108, 103);
+INSERT INTO order_meals (order_id, meal_id) VALUES (108, 104);
+
+-- Zamówienie 109
+INSERT INTO order_meals (order_id, meal_id) VALUES (109, 105);
+INSERT INTO order_meals (order_id, meal_id) VALUES (109, 106);
+
+-- Zamówienie 110
+INSERT INTO order_meals (order_id, meal_id) VALUES (110, 101);
+INSERT INTO order_meals (order_id, meal_id) VALUES (110, 102);
+
+-- Zamówienie 111
+INSERT INTO order_meals (order_id, meal_id) VALUES (111, 103);
+INSERT INTO order_meals (order_id, meal_id) VALUES (111, 104);
+
+-- Zamówienie 112
+INSERT INTO order_meals (order_id, meal_id) VALUES (112, 105);
+INSERT INTO order_meals (order_id, meal_id) VALUES (112, 106);
+
+-- Zamówienie 113
+INSERT INTO order_meals (order_id, meal_id) VALUES (113, 101);
+INSERT INTO order_meals (order_id, meal_id) VALUES (113, 102);
+
+-- Zamówienie 114
+INSERT INTO order_meals (order_id, meal_id) VALUES (114, 103);
+INSERT INTO order_meals (order_id, meal_id) VALUES (114, 104);
+
+-- Zamówienie 115
+INSERT INTO order_meals (order_id, meal_id) VALUES (115, 105);
+INSERT INTO order_meals (order_id, meal_id) VALUES (115, 106);
+
+-- Zamówienie 116
+INSERT INTO order_meals (order_id, meal_id) VALUES (116, 101);
+INSERT INTO order_meals (order_id, meal_id) VALUES (116, 102);
+
+-- Zamówienie 117
+INSERT INTO order_meals (order_id, meal_id) VALUES (117, 103);
+INSERT INTO order_meals (order_id, meal_id) VALUES (117, 104);
+
+-- Zamówienie 118
+INSERT INTO order_meals (order_id, meal_id) VALUES (118, 105);
+INSERT INTO order_meals (order_id, meal_id) VALUES (118, 106);
+
+-- Zamówienie 119
+INSERT INTO order_meals (order_id, meal_id) VALUES (119, 101);
+INSERT INTO order_meals (order_id, meal_id) VALUES (119, 102);
+
+-- Zamówienie 120
+INSERT INTO order_meals (order_id, meal_id) VALUES (120, 103);
+INSERT INTO order_meals (order_id, meal_id) VALUES (120, 104);
+
+-- Zamówienie 121
+INSERT INTO order_meals (order_id, meal_id) VALUES (121, 103);
+INSERT INTO order_meals (order_id, meal_id) VALUES (121, 104);

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -44,7 +44,9 @@ CREATE TABLE IF NOT EXISTS orders (
     opinion TEXT,
     rate INT NOT NULL,
     starting_address VARCHAR(255) NOT NULL,
-    destination_address VARCHAR(255) NOT NULL
+    destination_address VARCHAR(255) NOT NULL,
+    total_price NUMERIC(10, 2),
+    completed_at TIMESTAMP
 );
 
 -- Tworzenie tabeli 'meal'

--- a/backend/src/test/java/com/kateringapp/backend/MealsUnitTest.java
+++ b/backend/src/test/java/com/kateringapp/backend/MealsUnitTest.java
@@ -1,5 +1,6 @@
 package com.kateringapp.backend;
 
+import com.kateringapp.backend.configurations.SpringContextRetriever;
 import com.kateringapp.backend.dtos.MealCreateDTO;
 import com.kateringapp.backend.dtos.MealGetDTO;
 import com.kateringapp.backend.entities.Meal;
@@ -44,6 +45,9 @@ class MealsUnitTest {
     @InjectMocks
     private MealsService mealsService;
 
+    @Mock
+    private SpringContextRetriever springContextRetriever;
+
     private Meal meal;
     private MealCreateDTO mealCreateDTO;
     private CateringFirmData cateringFirmData;
@@ -74,9 +78,10 @@ class MealsUnitTest {
                 .description("Delicious sample meal")
                 .build();
 
-        // Mockowanie SecurityContextHolder
         Jwt jwt = mock(Jwt.class);
         when(jwt.getClaimAsString("sub")).thenReturn(cateringFirmId.toString());
+
+        when(springContextRetriever.getCurrentUserIdFromJwt()).thenReturn(cateringFirmId);
 
         Authentication authentication = mock(Authentication.class);
         when(authentication.isAuthenticated()).thenReturn(true);


### PR DESCRIPTION
W tym PR zrobiłem endpoint do pobierania danych do wykresu zysków. Po podaniu odpowiednich parametrów wyszukiwania, zwrócona zostanie List<OrderStatisticsDTO> zawierająca datę i łączną sprzedaż posiłków firmy danego dnia. Co więcej dodałem więcej danych do data seeder'a i teraz baza H2 jest zgodna z postgresem, więc już powinien się postgres odpalać. W encji order na stałe dodałem pole TotalPrice, żeby nie sumować przy każdym pobieraniu z bazy danych orderu. Niżej zamieszczam DTO's i przykłady parametrów. 

Kryteria pobierania danych do wykresu:
public class OrderStatisticCriteria {
    Timestamp startDate;
    Timestamp endDate;
    StatisticsPeriod statisticsPeriod; 
}

StatisticPeriod to jest enum, który przyjmuje wartości: WEEK, MONTH, YEAR. Oznacza to, że wyświetlone zostaną zyski z ostatniego tygodnia/miesiąca/roku.

Przykłady podawanych parametrów
{
  "startDate": "2024-04-10 00:00:00",
  "endDate": "2024-04-10 00:00:00"
}

{
  "statisticsPeriod": "WEEK"
}
