### PR TITLE
Order compatibility fixes

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,6 +53,10 @@
 			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-admin-client</artifactId>
 			<version>26.0.0</version>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,10 +53,6 @@
 			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-admin-client</artifactId>
 			<version>26.0.0</version>

--- a/backend/src/main/java/com/kateringapp/backend/controllers/OrderController.java
+++ b/backend/src/main/java/com/kateringapp/backend/controllers/OrderController.java
@@ -4,6 +4,7 @@ import com.kateringapp.backend.controllers.interfaces.IOrders;
 import com.kateringapp.backend.dtos.OrderDTO;
 import com.kateringapp.backend.dtos.criteria.OrderCriteria;
 import com.kateringapp.backend.services.interfaces.IOrderService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.security.access.annotation.Secured;
@@ -30,7 +31,7 @@ public class OrderController implements IOrders {
     @Override
     @Secured("ROLE_client")
     @PostMapping
-    public OrderDTO createOrder(@RequestBody OrderDTO orderDTO, @AuthenticationPrincipal Jwt token) {
+    public OrderDTO createOrder(@Valid @RequestBody OrderDTO orderDTO, @AuthenticationPrincipal Jwt token) {
         return orderService.createOrder(orderDTO, token);
     }
 

--- a/backend/src/main/java/com/kateringapp/backend/dtos/OrderDTO.java
+++ b/backend/src/main/java/com/kateringapp/backend/dtos/OrderDTO.java
@@ -2,6 +2,7 @@ package com.kateringapp.backend.dtos;
 
 import com.kateringapp.backend.entities.order.ContactData;
 import com.kateringapp.backend.entities.order.OrderStatus;
+import com.kateringapp.backend.entities.order.PaymentMethod;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,15 +16,16 @@ import java.util.List;
 @Getter
 public class OrderDTO {
 
-    private Long id;
+    private Long orderId;
     @NotNull
     private List<Long> mealIds;
     private String opinion;
     private BigDecimal totalPrice;
     private int rate;
     private OrderStatus orderStatus;
+    @NotNull
+    private PaymentMethod paymentMethod;
     private String startingAddress;
-    private String destinationAddress;
     @NotNull
     private ContactData contactData;
 }

--- a/backend/src/main/java/com/kateringapp/backend/entities/order/ContactData.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/order/ContactData.java
@@ -1,5 +1,6 @@
 package com.kateringapp.backend.entities.order;
 
+import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Embeddable
 @NoArgsConstructor
 public class ContactData {
 
@@ -20,6 +22,8 @@ public class ContactData {
     private String email;
     @NotNull
     private String phoneNumber;
+    @NotNull
+    private String destinationAddress;
     private LocalDateTime orderDateTime;
     private LocalDateTime dueDateTime;
 }

--- a/backend/src/main/java/com/kateringapp/backend/entities/order/Order.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/order/Order.java
@@ -39,12 +39,12 @@ public class Order {
     private Long id;
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
-
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
     private UUID clientId;
     private String opinion;
     private int rate;
     private String startingAddress;
-    private String destinationAddress;
     @ManyToMany
     @Builder.Default
     @JoinTable(

--- a/backend/src/main/java/com/kateringapp/backend/entities/order/PaymentMethod.java
+++ b/backend/src/main/java/com/kateringapp/backend/entities/order/PaymentMethod.java
@@ -1,0 +1,7 @@
+package com.kateringapp.backend.entities.order;
+
+public enum PaymentMethod {
+
+    BLIK, CREDIT_CARD, PAYPAL
+
+}

--- a/backend/src/test/java/com/kateringapp/backend/data/TestDataProvider.java
+++ b/backend/src/test/java/com/kateringapp/backend/data/TestDataProvider.java
@@ -15,11 +15,10 @@ public class TestDataProvider {
 
     public static OrderDTO provideOrderDTO() {
         return OrderDTO.builder()
-                .id(1L)
+                .orderId(1L)
                 .rate(3)
                 .orderStatus(OrderStatus.PENDING)
                 .startingAddress("aaa")
-                .destinationAddress("bbb")
                 .opinion("good")
                 .mealIds(Collections.emptyList())
                 .build();
@@ -31,7 +30,6 @@ public class TestDataProvider {
                 .rate(3)
                 .orderStatus(OrderStatus.PENDING)
                 .startingAddress("aaa")
-                .destinationAddress("bbb")
                 .opinion("good")
                 .clientId(UUID.randomUUID())
                 .build();


### PR DESCRIPTION
Hejhej. Endpoint jest już kompatybilny z formularzem, bo dodałem `paymentMethod`. Niżej zamieszczam przykładowy request i response dla niego, żeby wiadomo było jak powinny wyglądać. Co wartości zwracanej, to dostajemy całe DTO, z którego można wyciągnąć orderId. Oprócz tego co było wymagane, naprawiłem jeszcze liczenie ceny zamówienia i dodawanie więcej niż jednego, tego samego posiłku do niego, bo wcześniej pomimo takiej funkcjonalności na fronie, tego nie było.

Przykładowy request:
![obraz_2025-01-06_155113129](https://github.com/user-attachments/assets/af7d3709-3cc5-4c93-a762-46e8f419cc62)

Response: 
![image](https://github.com/user-attachments/assets/203fb6e1-d14f-4721-8a43-d398512b6fcb)
